### PR TITLE
fixed typescript errors for strict usage

### DIFF
--- a/packages/slate-vue/components/children.tsx
+++ b/packages/slate-vue/components/children.tsx
@@ -12,7 +12,7 @@ import {fragment} from './fragment';
  * Children.
  */
 
-const Children = tsx.component({
+const Children: any = tsx.component({
   props: {
     node: Object
   },
@@ -27,7 +27,7 @@ const Children = tsx.component({
     elementWatcherPlugin(this, 'children')
   },
   render() {
-    const editor: any = this.$editor;
+    const editor: any = (this as any).$editor;
     const {node} = this;
     const path = VueEditor.findPath(editor, node)
     const isLeafBlock =

--- a/packages/slate-vue/components/element.tsx
+++ b/packages/slate-vue/components/element.tsx
@@ -5,6 +5,7 @@
  */
 import * as tsx from "vue-tsx-support"
 import { Editor, Node } from 'slate'
+// @ts-ignore
 import getDirection from 'direction'
 
 import Text from './text'
@@ -30,9 +31,9 @@ export const Element = tsx.component({
     elementWatcherPlugin(this, 'element')
   },
   hooks() {
-    const ref = this.ref = useRef(null);
+    const ref = (this as any).ref = useRef(null);
     const element = this.element
-    const key = VueEditor.findKey(this.$editor, element)
+    const key = VueEditor.findKey((this as any).$editor, element)
 
     useEffect(()=>{
       if (ref.current) {
@@ -47,8 +48,8 @@ export const Element = tsx.component({
   },
   render(h) {
     // call renderElement with children, attribute and element
-    const {element, renderElement = DefaultElement, ref} = this;
-    const editor = this.$editor
+    const {element, renderElement = DefaultElement, ref} = this as any;
+    const editor = (this as any).$editor
     const isInline = editor.isInline(element)
     let children: JSX.Element | null = (
       <Children
@@ -83,14 +84,14 @@ export const Element = tsx.component({
     if (Editor.isVoid(editor, element)) {
       attributes['data-slate-void'] = true
 
-      if (!this.readOnly && isInline) {
+      if (!(this as any).readOnly && isInline) {
         attributes.contentEditable = false
       }
 
       const Tag = isInline ? 'span' : 'div'
       const [[text]] = Node.texts(element)
 
-      children = this.readOnly ? null : (
+      children = (this as any).readOnly ? null : (
         <Tag
           data-slate-spacer
           style={{
@@ -124,7 +125,7 @@ export const DefaultElement = (props: RenderElementProps) => {
   return tsx.component({
     render() {
       const { attributes, children, element } = props
-      const editor = this.$editor
+      const editor = (this as any).$editor
       const Tag = editor.isInline(element) ? 'span' : 'div'
       return (
         <Tag {...{attrs: attributes}} style={{ position: 'relative' }}>

--- a/packages/slate-vue/components/fragment.tsx
+++ b/packages/slate-vue/components/fragment.tsx
@@ -1,7 +1,7 @@
 // forked from vue-fragment
 // https://github.com/y-nk/vue-fragment
 import * as tsx from 'vue-tsx-support'
-const freeze = (object, property, value) => {
+const freeze = (object: any, property: any, value: any) => {
   Object.defineProperty(object, property, {
     configurable: true,
     get() { return value; },
@@ -9,7 +9,7 @@ const freeze = (object, property, value) => {
   });
 };
 
-const unfreeze = (object, property, value = null) => {
+const unfreeze = (object: any, property: any, value: any = null) => {
   Object.defineProperty(object, property, {
     configurable: true,
     writable: true,
@@ -47,8 +47,8 @@ export const fragment = tsx.component({
   // },
 
   mounted() {
-    const container = this.$el;
-    const parent = container.parentNode;
+    const container: any = this.$el;
+    const parent: any = container.parentNode;
 
     const head = document.createComment(`fragment#${this.name}#head`)
     const tail = document.createComment(`fragment#${this.name}#tail`)
@@ -56,17 +56,17 @@ export const fragment = tsx.component({
     parent.insertBefore(head, container)
     parent.insertBefore(tail, container)
 
-    container.appendChild = (node) => {
+    container.appendChild = (node: any) => {
       parent.insertBefore(node, tail)
       freeze(node, 'parentNode', container)
     }
 
-    container.insertBefore = (node, ref) => {
+    container.insertBefore = (node: any, ref: any) => {
       parent.insertBefore(node, ref)
       freeze(node, 'parentNode', container)
     }
 
-    container.removeChild = (node) => {
+    container.removeChild = (node: any) => {
       parent.removeChild(node)
       unfreeze(node, 'parentNode')
     }
@@ -84,12 +84,12 @@ export const fragment = tsx.component({
     freeze(tail, 'parentNode', container)
 
     const insertBefore = parent.insertBefore;
-    parent.insertBefore = (node, ref) => {
+    parent.insertBefore = (node: any, ref: any) => {
       insertBefore.call(parent, node, ref !== container ? ref : head)
     }
 
     const removeChild = parent.removeChild;
-    parent.removeChild = (node) => {
+    parent.removeChild = (node: any) => {
       if (node === container) {
         while(head.nextSibling !== tail)
           container.removeChild(head.nextSibling)

--- a/packages/slate-vue/components/leaf.tsx
+++ b/packages/slate-vue/components/leaf.tsx
@@ -20,9 +20,9 @@ const Leaf = tsx.component({
     fragment
   },
   render(h) {
-    const { renderLeaf = DefaultLeaf, text, leaf} = this;
+    const { renderLeaf = DefaultLeaf, text, leaf} = this as any;
     let children =  (
-      <string text={text} editor={this.$editor} leaf={leaf}/>
+      <string text={text} editor={(this as any).$editor} leaf={leaf}/>
       );
     if (leaf[PLACEHOLDER_SYMBOL]) {
       children = (

--- a/packages/slate-vue/components/slate.tsx
+++ b/packages/slate-vue/components/slate.tsx
@@ -25,7 +25,7 @@ export const Slate = tsx.component({
     // This method is forked from Vuex, but is not an efficient methods, still need to be improved
     // prepare two objects, one for immer, the other for vue
     // when we get immer result, patch it to vue
-    this.renderSlate()
+    ;(this as any).renderSlate()
   },
   watch: {
     value(newVal, oldVal) {
@@ -52,24 +52,24 @@ export const Slate = tsx.component({
      * force slate render by change fragment name
      * @param newVal
      */
-    renderSlate(newVal) {
+    renderSlate(newVal: any) {
       const value = newVal || this.value
-      this.$editor.children = JSON.parse(value);
+      ;(this as any).$editor.children = JSON.parse(value);
       const $$data = JSON.parse(value);
-      this.$editor._state= Vue.observable($$data)
-      this.name = this.genUid()
+      ;(this as any).$editor._state= Vue.observable($$data)
+      ;(this as any).name = this.genUid()
     }
   },
   render() {
-    EDITOR_TO_ON_CHANGE.set(this.$editor,()=>{
+    EDITOR_TO_ON_CHANGE.set((this as any).$editor,()=>{
       // patch to update all use
       // update editable manual
       // notify all update
-      this.$editor._state.__ob__.dep.notify()
+      ;(this as any).$editor._state.__ob__.dep.notify()
       // update focus manual
-      const gvm = getGvm(this.$editor)
-      gvm.focused = VueEditor.isFocused(this.$editor)
-      let op = this.$editor._operation
+      const gvm = getGvm((this as any).$editor)
+      gvm.focused = VueEditor.isFocused((this as any).$editor)
+      let op = (this as any).$editor._operation
       if(op && op.type === 'set_selection') {
         gvm.updateSelected()
       }
@@ -78,7 +78,7 @@ export const Slate = tsx.component({
     })
     return (
       <fragment name={this.name}>
-        {this.$scopedSlots.default()}
+        {(this as any).$scopedSlots.default()}
       </fragment>
     )
   }

--- a/packages/slate-vue/components/string.tsx
+++ b/packages/slate-vue/components/string.tsx
@@ -53,7 +53,7 @@ const string = tsx.component({
     TextString
   },
   render() {
-    const { leaf, editor,isLast, parent, text } = this
+    const { leaf, editor, isLast, parent, text } = this as any
     const path = VueEditor.findPath(editor, text)
     const parentPath = Path.parent(path)
 

--- a/packages/slate-vue/components/text.tsx
+++ b/packages/slate-vue/components/text.tsx
@@ -37,9 +37,9 @@ const Text = tsx.component({
     }
   },
   hooks() {
-    const ref = this.ref = useRef(null);
+    const ref = (this as any).ref = useRef(null);
     const {text} = this;
-    const editor = this.$editor;
+    const editor = (this as any).$editor;
     const key = VueEditor.findKey(editor, text)
     const initRef = () => {
       useEffect(()=>{
@@ -57,12 +57,12 @@ const Text = tsx.component({
     initRef()
   },
   render(h, ctx) {
-    const { text, placeholder } = this
-    let decorations = this.decorations;
+    const { text, placeholder } = this as any
+    let decorations: any = this.decorations;
     if(!decorations) {
-      const editor = this.$editor
+      const editor = (this as any).$editor
       const p = VueEditor.findPath(editor, text)
-      decorations = this.decorate([text, p])
+      decorations = (this as any).decorate([text, p])
 
       // init placeholder
       if (
@@ -91,7 +91,7 @@ const Text = tsx.component({
         )
     }
     return (
-      <span data-slate-node="text" ref={this.ref.id}>
+      <span data-slate-node="text" ref={(this as any).ref.id}>
         {children}
       </span>
     )

--- a/packages/slate-vue/plugins/runtime-util.ts
+++ b/packages/slate-vue/plugins/runtime-util.ts
@@ -340,7 +340,7 @@ export const runtimeNode = {
   }
 }
 
-export const isVueObject = (obj) => {
+export const isVueObject = (obj: any) => {
   return obj.__ob__
 }
 

--- a/packages/slate-vue/plugins/slate-plugin.ts
+++ b/packages/slate-vue/plugins/slate-plugin.ts
@@ -18,7 +18,7 @@ const createGvm = () => {
     },
     methods: {
       updateSelected() {
-        const editor = GVM_TO_EDITOR.get(this)
+        const editor = GVM_TO_EDITOR.get(this) as VueEditor
         const {selection} = editor
         if(selection) {
           this.selected.elements.forEach(node => {
@@ -42,7 +42,7 @@ export const getGvm = (editor: VueEditor) => {
 }
 
 // for element and element[]
-export const elementWatcherPlugin = (vm, type) => {
+export const elementWatcherPlugin = (vm: any, type: string) => {
   const update = vm._watcher.update;
   vm._watcher.update = () => {
     const op: Operation = vm.$editor._operation;
@@ -64,22 +64,24 @@ export const elementWatcherPlugin = (vm, type) => {
 
 export const SlateMixin = {
   mounted() {
-    const editor = this.$editor
-    editor._state.__ob__.dep.addSub(this._watcher)
+    const editor = (this as any).$editor
+    editor._state.__ob__.dep.addSub((this as any)._watcher)
   }
 }
 
 export const SelectedMixin = {
   created() {
-    const gvm = getGvm(this.$editor)
-    const element = this.element || this.node
+    const gvm = getGvm((this as any).$editor)
+    const element = (this as any).element || (this as any).node
     gvm.selected.elements.push(element)
   },
   computed: {
     selected() {
-      if(this.element) {
-        const gvm = getGvm(this.$editor)
-        return gvm.selected[NODE_TO_KEY.get(this.element).id]
+      if((this as any).element) {
+        const gvm = getGvm((this as any).$editor)
+        const key = NODE_TO_KEY.get((this as any).element)
+        if(!key) return false
+        return gvm.selected[key.id]
       } else {
         return false
       }
@@ -90,7 +92,7 @@ export const SelectedMixin = {
 export const ReadOnlyMixin = {
   computed: {
     readOnly() {
-      const gvm = getGvm(this.$editor)
+      const gvm = getGvm((this as any).$editor)
       return gvm.readOnly
     }
   }
@@ -99,7 +101,7 @@ export const ReadOnlyMixin = {
 export const FocusedMixin = {
   computed: {
     focused() {
-      const gvm = getGvm(this.$editor)
+      const gvm = getGvm((this as any).$editor)
       return gvm.focused
     }
   }
@@ -114,7 +116,7 @@ export const createEditorInstance = () => {
 }
 
 export const SlatePlugin = {
-  install(Vue, options) {
+  install(Vue: any, options: any) {
     Vue.mixin({
       beforeCreate() {
         if(!this.$editor) {

--- a/packages/slate-vue/plugins/vue-runtime.ts
+++ b/packages/slate-vue/plugins/vue-runtime.ts
@@ -22,8 +22,8 @@ const runtime = () => {
   }
 }
 
-export const vueRuntimeFunc = (func): any => {
-  return (...args) => {
+export const vueRuntimeFunc = (func: any): any => {
+  return (...args: any) => {
     const restore = runtime()
     const result = func(...args)
     restore()
@@ -31,7 +31,7 @@ export const vueRuntimeFunc = (func): any => {
   }
 }
 
-export const vueRuntime = (func, ...args): any => {
+export const vueRuntime = (func: any, ...args: any): any => {
   const restore = runtime()
   const result = func(...args)
   restore()

--- a/packages/slate-vue/utils/hotkeys.ts
+++ b/packages/slate-vue/utils/hotkeys.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { isKeyHotkey } from 'is-hotkey'
 import { IS_APPLE } from './environment'
 
@@ -49,9 +50,9 @@ const WINDOWS_HOTKEYS = {
  */
 
 const create = (key: string) => {
-  const generic = HOTKEYS[key]
-  const apple = APPLE_HOTKEYS[key]
-  const windows = WINDOWS_HOTKEYS[key]
+  const generic = (HOTKEYS as any)[key]
+  const apple = (APPLE_HOTKEYS as any)[key]
+  const windows = (WINDOWS_HOTKEYS as any)[key]
   const isGeneric = generic && isKeyHotkey(generic)
   const isApple = apple && isKeyHotkey(apple)
   const isWindows = windows && isKeyHotkey(windows)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "strict": false,
+    "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",


### PR DESCRIPTION
I wasn't able to disable typescript error checking within my Nuxt typescript project for `slate-vue` but it generated over 50-100 errors, so the only alternative was to fix those errors. It's not perfect as it used `as any` quite often, but the errors are gone and everything works the same AFAIK.